### PR TITLE
Include possibility to filter feed entries by locales.

### DIFF
--- a/config/feedamic.php
+++ b/config/feedamic.php
@@ -224,5 +224,25 @@ return [
     |
     */
 
-    'limit' => null
+    'limit' => null,
+
+
+    /*
+    |--------------------------------------------------------------------------
+    | DEFAULTS: Locales
+    |--------------------------------------------------------------------------
+    |
+    | This is the default that applies to all configured 'feeds', unless overwritten
+    | for a specific feed configuration.
+    |
+    | Limits the entries local to a list of locales, e. g.
+    | 'locales' => ['com', 'uk']
+    |
+    | To include only the current locale, provide the special 'current' string:
+    | 'locales' => 'current'
+    |
+    | When not set or null, all locales will be included.
+    */
+
+    'locales' => null,
 ];

--- a/config/feedamic.php
+++ b/config/feedamic.php
@@ -242,6 +242,7 @@ return [
     | 'locales' => 'current'
     |
     | When not set or null, all locales will be included.
+    |
     */
 
     'locales' => null,


### PR DESCRIPTION
When using the multi-site feature of Statamic, there might be feed collections available in multiple languages. This feature adds the abilitiy to only show entries for a given set of locales.

The default behavior is to show entries of all locales (to ensure backwards compatibility). To limit the entries locales, an array of locales can be provided. To show entries of the current local only, the special keyword 'current' can be used.