### PR TITLE
Correctly invalidate feeds with custom locale settings.

### DIFF
--- a/src/Facades/Feedamic.php
+++ b/src/Facades/Feedamic.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace MityDigital\Feedamic\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ *
+ * @method static string version()
+ * @method static \Illuminate\Config\Repository|Application|mixed getConfigValue(string|null $feed, string $key, mixed|null $default = null, bool|null $useDefaultIfEmpty = null)
+ * @method static string getCacheKey(string|null $feed = '', string $type = '', string $forcedLocale = '')
+ * @method static string|array getLocales(string|null $feed = '')
+ * @method static array getCollection(string|null $feed = '')
+ * @method static string getLocalesCacheKey(string|null $feed = '')
+ * @method static getCacheClearingKeys array(string|null $feed, array $types)
+ *
+ * @see \MityDigital\Feedamic\Feedamic
+ */
+class Feedamic extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return 'feedamic';
+    }
+}

--- a/src/Feedamic.php
+++ b/src/Feedamic.php
@@ -3,11 +3,194 @@
 namespace MityDigital\Feedamic;
 
 use Statamic\Facades\Addon;
+use Statamic\Facades\Site;
 
 class Feedamic
 {
     public static function version(): string
     {
         return Addon::get('mitydigital/feedamic')->version();
+    }
+
+    /**
+     * Some helper logic to get the config (or a fallback) from the Feedamic config array
+     *
+     * @param  string|null  $feed
+     * @param  string  $key
+     * @param  mixed|null  $default
+     * @param  bool|null  $useDefaultIfEmpty
+     * @return \Illuminate\Config\Repository|Application|mixed
+     */
+    public function getConfigValue(
+        string|null $feed,
+        string $key,
+        mixed $default = null,
+        bool $useDefaultIfEmpty = null
+    ) {
+        // set the location
+        $location = '';
+
+        // do we have a feed, and does the "feeds" config exist?
+        if (static::version() >= '2.2.0' && $feed && config('feedamic.feeds', false)) {
+            // if so, does the key exist in there?
+            if (config()->has('feedamic.feeds.' . $feed . '.' . $key)) {
+                $location = 'feedamic.feeds.' . $feed . '.' . $key;
+            }
+        }
+
+        if (!$location) {
+            // no 'feeds', so look for the core value
+            $location = 'feedamic.' . $key;
+        }
+
+        $value = config($location, $default);
+
+        if ($useDefaultIfEmpty && $default && !$value) {
+            return $default;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Get the cache key for a feed.
+     * Depending on the addon's version and provided parameters, the cache key is extended by them.
+     *
+     * @param string $feed
+     * @param string $type
+     * @param string $forcedLocale
+     * @return string
+     */
+    public function getCacheKey(string|null $feed = '', string $type = '', string $forcedLocale = '')
+    {
+        // conditionally build up an array of cache key parts
+        $cacheKeyParts = [];
+
+        $cacheKeyParts[] = config('feedamic.cache');
+
+        if (static::version() >= '2.2.0' && $feed) {
+            $cacheKeyParts[] = $feed;
+        }
+
+        if ($forcedLocale) {
+            $cacheKeyParts[] = $forcedLocale;
+        } else {
+            $cacheKeyParts[] = $this->getLocalesCacheKey($feed);
+        }
+
+        if ($type) {
+            $cacheKeyParts[] = $type;
+        }
+
+        // glue the cache key parts together to the actual string
+        return implode('.', $cacheKeyParts);
+    }
+
+    /**
+     * Get the locale/s for a feed
+     *
+     * @param string $feed
+     * @return string|array
+     */
+    public function getLocales(string|null $feed = '')
+    {
+        // filter entries by their locales; include all locales by default
+        $locales = $this->getConfigValue($feed, 'locales', '*', true);
+
+        // dynamically get current site handle for special locales value 'current'
+        return $locales === 'current' ? [Site::current()->handle()] : $locales;
+    }
+
+    /**
+     * Get the configured collections for a feed.
+     *
+     * @param string $feed
+     * @return array
+     */
+    public function getCollections(string|null $feed = '')
+    {
+        // v2.2 or above
+        if (static::version() >= '2.2.0' && $feed) {
+            return config('feedamic.feeds.' . $feed . '.collections');
+        }
+
+        // v2.1 or below
+        return config('feedamic.collections');
+    }
+
+    /**
+     * Get the cache key part for the configured locales.
+     *
+     * @param string|null $feed
+     * @return string
+     */
+    public function getLocalesCacheKey(string|null $feed = '')
+    {
+        $locales = $this->getLocales($feed);
+
+        if (is_array($locales)) {
+            $localesCacheKey = implode('.', $locales);
+        } else {
+            $localesCacheKey = $locales;
+        }
+
+        return $localesCacheKey;
+    }
+
+    /**
+     * Returns an array of the feed's cache keys.
+     *
+     * There are 3 scenarios to handle:
+     *
+     * 1: 'current'
+     * The feed should only contain entries from the current site.
+     * On a multisite this means, that there might be cache keys for every site's handle:
+     * feedamic.news.us, feedamic.news.fr, feedamic.news.de, ...
+     * Due to this dynamic nature of the 'current' configuration, it is necessary to clear
+     * the caches for all the site handles.
+     *
+     * 2: '*'
+     * The feed contains entries from all sites.
+     * As only a single cache key is needed - feedamic.news.* - only this sinlge cache key
+     * has to be cleared.
+     *
+     * 3: custom array of locales, e. g. ['com', 'fr']
+     * The feed contains entries from custom locales.
+     * In its current implementation, the cache key for all site's feeds is the same.
+     * Therefore only this single cache key - feedamic.news.com.fr - has to be invalidated.
+     *
+     * @param string $feed
+     * @param array $types
+     * @return array
+     */
+    public function getCacheClearingKeys(string|null $feed, array $types)
+    {
+        $cacheKeys = collect();
+
+        $feedLocales = $this->getConfigValue($feed, 'locales', '*', true);
+
+        switch ($feedLocales) {
+            case 'current':
+                $cacheLocales = Site::all()->map(function ($site) {
+                    return $site->handle();
+                })->values();
+                break;
+
+            case '*':
+                $cacheLocales = ['*'];
+                break;
+
+            default:
+                $cacheLocales = [implode('.', $feedLocales)];
+        }
+
+        foreach ($types as $type) {
+            foreach ($cacheLocales as $cacheLocale) {
+                $cacheKeys->push($this->getCacheKey($feed, $type, $cacheLocale));
+                $cacheKeys->push($this->getCacheKey($feed, '', $cacheLocale));
+            }
+        }
+
+        return $cacheKeys->unique();
     }
 }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace MityDigital\Feedamic;
 
 use MityDigital\Feedamic\Commands\ClearCacheCommand;
+use MityDigital\Feedamic\Feedamic as FeedamicFeedamic;
 use MityDigital\Feedamic\Listeners\ClearFeedamicCache;
 use MityDigital\Feedamic\Tags\Feedamic;
 use Statamic\Events\EntrySaved;
@@ -23,7 +24,7 @@ class ServiceProvider extends AddonServiceProvider
     ];
 
     protected $routes = [
-        'web' => __DIR__.'/../routes/web.php',
+        'web' => __DIR__ . '/../routes/web.php',
     ];
 
     protected $tags = [
@@ -40,8 +41,11 @@ class ServiceProvider extends AddonServiceProvider
 
     public function bootAddon()
     {
+        $this->app->singleton(FeedamicFeedamic::class);
+        $this->app->alias(FeedamicFeedamic::class, 'feedamic');
+
         $this->publishes([
-            __DIR__.'/../resources/views' => resource_path('views/vendor/mitydigital/feedamic'),
+            __DIR__ . '/../resources/views' => resource_path('views/vendor/mitydigital/feedamic'),
         ], 'feedamic-views');
     }
 


### PR DESCRIPTION
This PR fixes correct cache invalidation for the new multi-site feature. It was possible to define custom locale for different sites, but the caching mechanism was not yet updated. That led to incorrect behavior, especially when using the 'current' keyword: all sites' feeds showed the same content due to the same cache key.

The cache key depends on the locales setting. To correctly invalidate the cache, the correct key has to be used. This is not a trivial task, as the locales configuration can mean different things.

Let's assume we have the following sites and feed URLs:
- website.com/feed/news
- website.fr/feed/news
- website.de/feed/news

Currently the following scenarios for multi-site feeds are supported:

#### 1. Show feeds of all sites on every site:
`'locales' => '*' // the default behavior, same as not defining locales at all`

All sites share the same cache key, something like `feedamic.news.*`, so invalidation is fairly easy.

#### 2. Each site shows its own feeds
`'locales' => 'current'`

Due to the dynamic nature of the 'current' locale, every sites' feed has a unique cache key:
- feedamic.news.com
- feedamic.news.fr
- feedamic.news.de

Cache invalidation by EntrySaved event is pretty straightforward. But when invalidating the cache via CLI, it gets complicated. Instead of introducing new CLI parameters, the cache for [all locales](https://github.com/Sm1lEE/statamic-feedamic/blob/324b5e64cdf4b46099565ab2ce1be34d62baada0/src/Feedamic.php#L173-L176) of the selected feeds are invalidated.
This is not ideal, as probably only a single locales' cache should be invalidated. I've chosen to do it the easy and invalidate the cache keys of all locales for this feed.

#### 3. Every site shows the same combination of locales
`'locales' => ['com', 'fr']`

Similar to 1. all feeds of all sites show the same content:
- website.com/feed/news --> com and fr entries
- website.fr/feed/news --> com and fr entries
- website.de/feed/news --> com and fr entries

Cache invalidation is basically the same as in 1.

---

In hindsight there is much that can be improved, e. g. define for every locale which locale feeds to show, so that something like this can be possible:
- website.com/feeds/news --> show com entries
- website.com/feeds/fr --> show com and fr entries
- website.com/feeds/de --> show com and de entries

The user configuration for this could get a little complicated, so I decided to skip this feature for now.

---

Because cache invalidation is the main focus of this PR, I've tried to unify the cache key handling for caching and cache invalidation. The main Feedamic.php class is extended by some helper functions that can be used throughout the addon. Additionally a facade for this class has been introduced to make it easier to work with it.

These are a lot of changes, but I hope to make the multi-site support of this addon better as it did not work as expected with the last changes.