### PR TITLE
Fix incorrect update date when building static site in CI

### DIFF
--- a/src/Http/Controllers/FeedamicController.php
+++ b/src/Http/Controllers/FeedamicController.php
@@ -257,7 +257,7 @@ class FeedamicController extends Controller
                         'summary' => $summary,
                         'image' => $image,
                         'published' => $entry->date(),
-                        'updated' => $entry->fileLastModified()
+                        'updated' => $entry->lastModified()
                     ]);
                 });
 


### PR DESCRIPTION
Thanks for the plugin!

Today, I noticed that the feed currently uses the file's last modification time, which isn't always a reliable indicator. Especially when cloning the repo in a CI environment where the dates will end up as the clone date.

The `lastModified` method returns a Carbon instance created from the `updated_at` field on the entry if it exists. Otherwise, it falls back to using the `fileLastModified` method.

I'm unsure whether this method exists in all versions of Statamic you support, so it may need to be wrapped in a conditional.