### PR TITLE
Include original entry object in `FeedEntry`

### DIFF
--- a/src/Http/Controllers/FeedamicController.php
+++ b/src/Http/Controllers/FeedamicController.php
@@ -311,7 +311,8 @@ class FeedamicController extends Controller
                         'summary' => $summary,
                         'image' => $image,
                         'published' => $entry->date(),
-                        'updated' => $entry->lastModified()
+                        'updated' => $entry->lastModified(),
+                        'entry' => $entry
                     ]);
                 });
 

--- a/src/Models/FeedEntry.php
+++ b/src/Models/FeedEntry.php
@@ -13,6 +13,7 @@ class FeedEntry
     public $title;
     public $updated;
     public $uri;
+    public $entry;
 
     public function __construct(array $attributes = [])
     {


### PR DESCRIPTION
If you're implementing custom feed views you might want to add additional data that's not included in the `FeedEntry`. 

This PR adds the original entry object so you can use other entry values in your custom views. 