### PR TITLE
Statamic 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 .DS_Store
 /node_modules
+vendor
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   ],
   "require": {
     "php": "^8.0",
-    "statamic/cms": "^3.3|^4.0"
+    "statamic/cms": "^5.0"
   },
   "extra": {
     "statamic": {
@@ -32,5 +32,6 @@
         "MityDigital\\Feedamic\\ServiceProvider"
       ]
     }
-  }
+  },
+  "minimum-stability": "dev"
 }


### PR DESCRIPTION
This pull request updates the addon to be compatible with Statamic 5.

Apologies for the early PR - I use this addon on my personal site and wanted to have a PR to patch in so I can deploy the alpha. Feel free to ignore until it's properly released 😆 

**Changes:** 

* Ignored the `vendor` directory and `composer.lock` file from version control
* Updated the `statamic/cms` version constraint in `composer.json`

From what I can tell, everything *seems* to be working fine with these changes. Although, obviously, you know this addon better than I do so I might have missed something.