### PR TITLE
Add support for a custom feedmodel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,10 @@
       ]
     }
   },
-  "minimum-stability": "dev"
+  "minimum-stability": "dev",
+  "config": {
+    "allow-plugins": {
+      "pixelfear/composer-dist-plugin": true
+    }
+  }
 }

--- a/config/feedamic.php
+++ b/config/feedamic.php
@@ -288,4 +288,17 @@ return [
     */
 
     'locales' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | DEFAULTS: Feed Model
+    |--------------------------------------------------------------------------
+    |
+    | This is the default model used to generate the feed.
+    |
+    | You can extend the default model to add additional functionality, or to
+    | override the default behaviour.
+    |
+    */
+    'model' => \MityDigital\Feedamic\Models\FeedEntry::class,
 ];

--- a/src/Http/Controllers/FeedamicController.php
+++ b/src/Http/Controllers/FeedamicController.php
@@ -309,8 +309,9 @@ class FeedamicController extends Controller
                     }
 
 
-                    // create a feed entry object
-                    return new FeedEntry([
+                    $feedModel = $this->getConfigValue($feed, 'model', FeedEntry::class, false);
+
+                    return new $feedModel([
                         'title' => $entryArray['title']->value(),
                         'author' => $author,
                         'uri' => $entry->absoluteUrl(),


### PR DESCRIPTION
Hi @martyf,

We need the ability to overwrite the URI in the feed model because we are using Statamic as a headless CMS. 

It would be great if you could add this change to the add-on.

Thanks Thomas and the @pixelpillow team! 