### PR TITLE
Explain need for publish dates on collections

### DIFF
--- a/config/feedamic.php
+++ b/config/feedamic.php
@@ -46,6 +46,7 @@ return [
 
             /*
             | An array of collections to include in the feed
+            | Each collection must be configured with Publish Dates enabled
             | Remove from the array to disable a specific feed type.
             */
             'collections' => [


### PR DESCRIPTION
Addresses #29

Feedamic requires collections to have Publish Dates enabled, so I suggest adding a line explaining this in the comments in this config file.