### PR TITLE
Add support for computed properties

### DIFF
--- a/src/Abstracts/AbstractFeedamicEntry.php
+++ b/src/Abstracts/AbstractFeedamicEntry.php
@@ -83,6 +83,11 @@ abstract class AbstractFeedamicEntry
                 if ($value = $this->entry->augmentedValue($handle)) {
                     $fieldValue = $value;
                     break;
+                } elseif ($this->entry->computedKeys()->contains($handle)) {
+                    if ($value = $this->entry->getComputed($handle)) {
+                        $fieldValue = $value;
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
If a field is marked as computed, it can now have its value retrieved in the `FeedamicEntry`, such as for the summary or content.