### PR TITLE
Require laravel/framework >= 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     }
   ],
   "require": {
-    "statamic/cms": "^5.59|^6.0"
+    "statamic/cms": "^5.59|^6.0",
+    "laravel/framework": "^11.0|^12.0"
   },
   "require-dev": {
     "laravel/pint": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
   ],
   "require": {
     "statamic/cms": "^5.59|^6.0",
-    "laravel/framework": "^11.0|^12.0"
+    "laravel/framework": "^11.35|^12.0"
   },
   "require-dev": {
     "laravel/pint": "^1.10",


### PR DESCRIPTION
Adds `laravel/framework` versions 11 and 12 as a composer requirement. Feedamic uses `Illuminate\Support\Uri` which is only available in Laravel >= 11, whereas Statamic 5.x supports Laravel 10. Encountered this when updating a Statamic site that had originally been on Statamic 3 and upgraded incrementally.

Could replace the `^11.0|^12.0` version requirement with `>=11.0` if you'd like minimal maintenance on future Laravel framework versions.