### PR TITLE
fix: use value() to properly resolve localized values with origin fallback

### DIFF
--- a/src/Abstracts/AbstractFeedamicEntry.php
+++ b/src/Abstracts/AbstractFeedamicEntry.php
@@ -79,7 +79,7 @@ abstract class AbstractFeedamicEntry
         // look at the map
         foreach ($map as $handle) {
             $fieldHandle = $handle; // always set
-            if ($this->entry->has($handle)) {
+            if ($this->entry->value($handle)) {
                 if ($value = $this->entry->augmentedValue($handle)) {
                     $fieldValue = $value;
                     break;


### PR DESCRIPTION
In a multisite setup `$this->entry->has($handle)` did not respect origin values when the localized entry did not have a value for `$handle`. Using `$this->entry->value($handle)` solves this issue.

## Example

### Origin
```
id: 1234
title: "this is the title"
```

### Localization
```
id: 5678
origin: 1234
```

### Old behavior
Calling `$this->entry->has($handle)` on the localized entry did return `null`, without respecting the origin value.

### New behaviour
Calling `$this->entry->value($handle)` on the localized entry correctly falls back to the origin value.